### PR TITLE
PR: Implement support for custom "Daylight" and "Blackbody" illuminants.

### DIFF
--- a/apps/common.py
+++ b/apps/common.py
@@ -97,6 +97,8 @@ Illuminant options for a :class:`Dropdown`class instance.
 ILLUMINANTS_OPTIONS : list
 """
 ILLUMINANT_OPTIONS.insert(0, {'label': 'Custom', 'value': 'Custom'})
+ILLUMINANT_OPTIONS.insert(1, {'label': 'Blackbody', 'value': 'Blackbody'})
+ILLUMINANT_OPTIONS.insert(1, {'label': 'Daylight', 'value': 'Daylight'})
 
 TEMPLATE_DEFAULT_OUTPUT = """
 IDT Matrix


### PR DESCRIPTION
This PR implements support for custom "Daylight" and "Blackbody" illuminants.

![image](https://user-images.githubusercontent.com/99779/129462773-35e443b2-ad2f-4410-a848-c9e9dea7d48a.png)

When choosing *Daylight* of *Blackbody*, a `Collapse` panel reveals the *CCT* `Field`:

![image](https://user-images.githubusercontent.com/99779/129462787-b676f82f-10e0-478d-b24d-38cb7515aed7.png)
