### PR TITLE
PR: Implement support for "colour" latest update WRT whitepoint preservation.

### DIFF
--- a/aces/idt/__init__.py
+++ b/aces/idt/__init__.py
@@ -8,7 +8,6 @@ from .common import (
 from .prosumer_camera import (
     generate_reference_colour_checker,
     archive_to_idt,
-    apply_idt,
     zip_idt,
     png_colour_checker_segmentation,
     png_grey_card_sampling,
@@ -26,7 +25,6 @@ __all__ = [
 __all__ += [
     "generate_reference_colour_checker",
     "archive_to_idt",
-    "apply_idt",
     "zip_idt",
     "png_colour_checker_segmentation",
     "png_grey_card_sampling",

--- a/aces/idt/common.py
+++ b/aces/idt/common.py
@@ -12,9 +12,7 @@ import re
 import unicodedata
 
 from colour.algebra import euclidean_distance, vector_dot
-from colour.characterisation import whitepoint_preserving_matrix
 from colour.models import RGB_COLOURSPACE_ACES2065_1, XYZ_to_Oklab, XYZ_to_IPT
-from colour.utilities import zeros
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa
@@ -163,7 +161,7 @@ def png_compare_colour_checkers(samples_test, samples_reference, columns=6):
     return data_png
 
 
-def optimisation_factory_Oklab(whitepoint_preservation: bool = True):
+def optimisation_factory_Oklab():
     """
     Produce the objective function and *CIE XYZ* colourspace to optimisation
     colourspace/colour model function based on the *Oklab* colourspace.
@@ -171,12 +169,6 @@ def optimisation_factory_Oklab(whitepoint_preservation: bool = True):
     The objective function returns the euclidean distance between the training
     data *RGB* tristimulus values and the training data *CIE XYZ* tristimulus
     values** in the *Oklab* colourspace.
-
-    Parameters
-    ----------
-    whitepoint_preservation
-        Whether to use whitepoint preservation, i.e. optimisation uses 6 terms
-        instead of 9 and rows summation is constrained to 1.
 
     Returns
     -------
@@ -196,13 +188,7 @@ def optimisation_factory_Oklab(whitepoint_preservation: bool = True):
     def objective_function(M, RGB, Jab):
         """*Oklab* colourspace based objective function."""
 
-        M = (
-            whitepoint_preserving_matrix(
-                np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
-            )
-            if whitepoint_preservation
-            else np.reshape(M, (3, 3))
-        )
+        M = np.reshape(M, [3, 3])
 
         XYZ_t = vector_dot(
             RGB_COLOURSPACE_ACES2065_1.matrix_RGB_to_XYZ, vector_dot(M, RGB)
@@ -219,7 +205,7 @@ def optimisation_factory_Oklab(whitepoint_preservation: bool = True):
     return objective_function, XYZ_to_optimization_colour_model
 
 
-def optimisation_factory_IPT(whitepoint_preservation: bool = True):
+def optimisation_factory_IPT():
     """
     Produce the objective function and *CIE XYZ* colourspace to optimisation
     colourspace/colour model function based on the *IPT* colourspace.
@@ -227,12 +213,6 @@ def optimisation_factory_IPT(whitepoint_preservation: bool = True):
     The objective function returns the euclidean distance between the training
     data *RGB* tristimulus values and the training data *CIE XYZ* tristimulus
     values** in the *IPT* colourspace.
-
-    Parameters
-    ----------
-    whitepoint_preservation
-        Whether to use whitepoint preservation, i.e. optimisation uses 6 terms
-        instead of 9 and rows summation is constrained to 1.
 
     Returns
     -------
@@ -252,13 +232,7 @@ def optimisation_factory_IPT(whitepoint_preservation: bool = True):
     def objective_function(M, RGB, Jab):
         """*IPT* colourspace based objective function."""
 
-        M = (
-            whitepoint_preserving_matrix(
-                np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
-            )
-            if whitepoint_preservation
-            else np.reshape(M, (3, 3))
-        )
+        M = np.reshape(M, [3, 3])
 
         XYZ_t = vector_dot(
             RGB_COLOURSPACE_ACES2065_1.matrix_RGB_to_XYZ, vector_dot(M, RGB)

--- a/aces/idt/common.py
+++ b/aces/idt/common.py
@@ -12,7 +12,9 @@ import re
 import unicodedata
 
 from colour.algebra import euclidean_distance, vector_dot
+from colour.characterisation import whitepoint_preserving_matrix
 from colour.models import RGB_COLOURSPACE_ACES2065_1, XYZ_to_Oklab, XYZ_to_IPT
+from colour.utilities import as_float_array, zeros
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa
@@ -173,22 +175,29 @@ def optimisation_factory_Oklab():
     Returns
     -------
     :class:`tuple`
-        Objective function and *CIE XYZ* colourspace to *Oklab* colourspace
-        function.
+        :math:`x_0` initial values, objective function, *CIE XYZ* colourspace
+        to *Oklab* colourspace function and finaliser function.
 
     Examples
     --------
     >>> optimisation_factory_Oklab()  # doctest: +SKIP
-    (<function optimisation_factory_Oklab.<locals>\
+    (array([ 1.,  0.,  0.,  1.,  0.,  0.]), \
+<function optimisation_factory_Oklab.<locals>\
 .objective_function at 0x...>, \
 <function optimisation_factory_Oklab.<locals>\
-.XYZ_to_optimization_colour_model at 0x...>)
+.XYZ_to_optimization_colour_model at 0x...>, \
+<function optimisation_factory_Oklab.<locals>.\
+finaliser_function at 0x...>)
     """
+
+    x_0 = as_float_array([1, 0, 0, 1, 0, 0])
 
     def objective_function(M, RGB, Jab):
         """*Oklab* colourspace based objective function."""
 
-        M = np.reshape(M, [3, 3])
+        M = whitepoint_preserving_matrix(
+            np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
+        )
 
         XYZ_t = vector_dot(
             RGB_COLOURSPACE_ACES2065_1.matrix_RGB_to_XYZ, vector_dot(M, RGB)
@@ -202,7 +211,19 @@ def optimisation_factory_Oklab():
 
         return XYZ_to_Oklab(XYZ)
 
-    return objective_function, XYZ_to_optimization_colour_model
+    def finaliser_function(M):
+        """Finaliser function."""
+
+        return whitepoint_preserving_matrix(
+            np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
+        )
+
+    return (
+        x_0,
+        objective_function,
+        XYZ_to_optimization_colour_model,
+        finaliser_function,
+    )
 
 
 def optimisation_factory_IPT():
@@ -217,22 +238,29 @@ def optimisation_factory_IPT():
     Returns
     -------
     :class:`tuple`
-        Objective function and *CIE XYZ* colourspace to *IPT* colourspace
-        function.
+        :math:`x_0` initial values, objective function, *CIE XYZ* colourspace
+        to *IPT* colourspace function and finaliser function.
 
     Examples
     --------
     >>> optimisation_factory_IPT()  # doctest: +SKIP
-    (<function optimisation_factory_IPT.<locals>\
+    (array([ 1.,  0.,  0.,  1.,  0.,  0.]), \
+<function optimisation_factory_IPT.<locals>\
 .objective_function at 0x...>, \
 <function optimisation_factory_IPT.<locals>\
-.XYZ_to_optimization_colour_model at 0x...>)
+.XYZ_to_optimization_colour_model at 0x...>, \
+<function optimisation_factory_IPT.<locals>.\
+finaliser_function at 0x...>)
     """
+
+    x_0 = as_float_array([1, 0, 0, 1, 0, 0])
 
     def objective_function(M, RGB, Jab):
         """*IPT* colourspace based objective function."""
 
-        M = np.reshape(M, [3, 3])
+        M = whitepoint_preserving_matrix(
+            np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
+        )
 
         XYZ_t = vector_dot(
             RGB_COLOURSPACE_ACES2065_1.matrix_RGB_to_XYZ, vector_dot(M, RGB)
@@ -246,4 +274,16 @@ def optimisation_factory_IPT():
 
         return XYZ_to_IPT(XYZ)
 
-    return objective_function, XYZ_to_optimization_colour_model
+    def finaliser_function(M):
+        """Finaliser function."""
+
+        return whitepoint_preserving_matrix(
+            np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
+        )
+
+    return (
+        x_0,
+        objective_function,
+        XYZ_to_optimization_colour_model,
+        finaliser_function,
+    )

--- a/aces/idt/prosumer_camera.py
+++ b/aces/idt/prosumer_camera.py
@@ -1089,8 +1089,8 @@ def matrix_idt(
         RGB_COLOURSPACE_ACES2065_1.matrix_RGB_to_XYZ, training_data
     )
 
-    RGB_w = 1 / samples_weighted[21]
-    k = RGB_w * XYZ[21]
+    RGB_w = 1 / np.mean(samples_weighted[18:], axis=0)
+    k = RGB_w * np.mean(XYZ[18:], axis=0)
     samples_weighted *= k
 
     RGB_w /= RGB_w[1]

--- a/aces/idt/prosumer_camera.py
+++ b/aces/idt/prosumer_camera.py
@@ -33,10 +33,7 @@ from colour import (
     sd_to_aces_relative_exposure_values,
 )
 from colour.algebra import smoothstep_function, vector_dot
-from colour.characterisation import (
-    optimisation_factory_rawtoaces_v1,
-    whitepoint_preserving_matrix,
-)
+from colour.characterisation import optimisation_factory_rawtoaces_v1
 from colour.models import RGB_COLOURSPACE_ACES2065_1, RGB_luminance
 from colour.io import LUT_to_LUT
 from colour.hints import Dict, NDArray, Optional, Union
@@ -49,7 +46,6 @@ from colour.utilities import (
     optional,
     orient,
     validate_method,
-    zeros,
 )
 from dataclasses import dataclass
 from pathlib import Path
@@ -1029,7 +1025,6 @@ def matrix_idt(
     training_data=RGB_COLORCHECKER_CLASSIC_ACES,
     optimisation_factory=optimisation_factory_rawtoaces_v1,
     optimisation_kwargs=None,
-    whitepoint_preservation=True,
     additional_data=False,
 ):
     """
@@ -1052,9 +1047,6 @@ def matrix_idt(
         optimisation colour model function.
     optimisation_kwargs : dict, optional
         Parameters for :func:`scipy.optimize.minimize` definition.
-    whitepoint_preservation
-        Whether to use whitepoint preservation, i.e. optimisation uses 6 terms
-        instead of 9 and rows summation is constrained to 1.
     additional_data : bool, optional
         Whether to return additional data.
 
@@ -1090,7 +1082,7 @@ def matrix_idt(
     (
         objective_function,
         XYZ_to_optimization_colour_model,
-    ) = optimisation_factory(whitepoint_preservation)
+    ) = optimisation_factory()
     optimisation_settings = {
         "method": "BFGS",
         "jac": "2-point",
@@ -1098,24 +1090,12 @@ def matrix_idt(
     if optimisation_kwargs is not None:
         optimisation_settings.update(optimisation_kwargs)
 
-    x_0 = (
-        np.identity(3)[..., :-1] if whitepoint_preservation else np.identity(3)
-    )
-
     M = minimize(
         objective_function,
-        x_0,
+        np.ravel(np.identity(3)),
         (samples_weighted, XYZ_to_optimization_colour_model(XYZ)),
         **optimisation_settings,
-    ).x
-
-    M = (
-        whitepoint_preserving_matrix(
-            np.hstack([np.reshape(M, (3, 2)), zeros((3, 1))])
-        )
-        if whitepoint_preservation
-        else np.reshape(M, (3, 3))
-    )
+    ).x.reshape([3, 3])
 
     if additional_data:
         return DataMatrixIdt(M, samples_weighted)

--- a/apps/common.py
+++ b/apps/common.py
@@ -194,8 +194,8 @@ INTERPOLATORS : dict
 
 OPTIMISATION_FACTORIES = {
     "Oklab": optimisation_factory_Oklab,
-    "IPT": optimisation_factory_IPT,
     "JzAzBz": optimisation_factory_Jzazbz,
+    "IPT": optimisation_factory_IPT,
     "CIE Lab": optimisation_factory_rawtoaces_v1,
 }
 """

--- a/apps/idt_calculator_p_2013_001.py
+++ b/apps/idt_calculator_p_2013_001.py
@@ -1033,13 +1033,8 @@ def compute_idt_p2013_001(
             apply_cctf_encoding=True,
         )
 
-    samples_idt = camera_RGB_to_ACES2065_1(RGB, M, np.ones(3))
-    samples_reference = XYZ_to_RGB(
-        XYZ,
-        RGB_COLOURSPACE_ACES2065_1.whitepoint,
-        RGB_COLOURSPACE_ACES2065_1.whitepoint,
-        RGB_COLOURSPACE_ACES2065_1.matrix_XYZ_to_RGB,
-    )
+    samples_idt = camera_RGB_to_ACES2065_1(RGB / RGB_w, M, RGB_w)
+    samples_reference = XYZ_to_RGB(XYZ, RGB_COLOURSPACE_ACES2065_1)
 
     compare_colour_checkers_idt_correction = png_compare_colour_checkers(
         RGB_working_to_RGB_display(samples_idt),

--- a/apps/idt_calculator_p_2013_001.py
+++ b/apps/idt_calculator_p_2013_001.py
@@ -336,22 +336,6 @@ _LAYOUT_COLUMN_OPTIONS_CHILDREN = [
                             ),
                             InputGroup(
                                 [
-                                    InputGroupText("Whitepoint Preservation"),
-                                    Select(
-                                        id=_uid(
-                                            "whitepoint-preservation-select"
-                                        ),
-                                        options=[
-                                            {"label": "1", "value": "1"},
-                                            {"label": "0", "value": "0"},
-                                        ],
-                                        value="0",
-                                    ),
-                                ],
-                                className="mb-1",
-                            ),
-                            InputGroup(
-                                [
                                     InputGroupText(
                                         "Camera Sensitivities Interpolator"
                                     ),
@@ -784,7 +768,6 @@ def toggle_advanced_options(n_clicks, is_open):
         State(_uid("training-data-select"), "value"),
         State(_uid("chromatic-adaptation-transform-select"), "value"),
         State(_uid("optimisation-space-select"), "value"),
-        State(_uid("whitepoint-preservation-select"), "value"),
         State(_uid("camera-sensitivities-interpolator-select"), "value"),
         State(_uid("illuminant-interpolator-select"), "value"),
         State(_uid("url"), "href"),
@@ -804,7 +787,6 @@ def compute_idt_p2013_001(
     training_data,
     chromatic_adaptation_transform,
     optimisation_space,
-    whitepoint_preservation,
     sensitivities_interpolator,
     illuminant_interpolator,
     href,
@@ -840,9 +822,6 @@ def compute_idt_p2013_001(
     optimisation_space : str
         Name of the optimisation space used to select the corresponding
         optimisation factory.
-    whitepoint_preservation : str
-        Whether to use whitepoint preservation, i.e. optimisation uses 6 terms
-        instead of 9 and rows summation is constrained to 1.
     sensitivities_interpolator : str
         Name of the camera sensitivities interpolator.
     illuminant_interpolator : str
@@ -887,7 +866,6 @@ def compute_idt_p2013_001(
         training_data,
         chromatic_adaptation_transform,
         optimisation_space,
-        whitepoint_preservation,
         sensitivities_interpolator,
         illuminant_interpolator,
     )
@@ -952,7 +930,6 @@ def compute_idt_p2013_001(
             training_data=training_dataset,
             optimisation_factory=optimisation_factory,
             chromatic_adaptation_transform=chromatic_adaptation_transform,
-            whitepoint_preservation=bool(int(whitepoint_preservation)),
             additional_data=True,
         )
 
@@ -996,7 +973,6 @@ def compute_idt_p2013_001(
                     "TrainingData": training_data,
                     "ChromaticAdaptationTransform": chromatic_adaptation_transform,
                     "OptimisationSpace": optimisation_space,
-                    "WhitePreservation": whitepoint_preservation,
                     "SensitivitiesInterpolator": sensitivities_interpolator,
                     "IlluminantInterpolator": illuminant_interpolator,
                 },

--- a/apps/idt_calculator_prosumer_camera.py
+++ b/apps/idt_calculator_prosumer_camera.py
@@ -19,6 +19,7 @@ from colour import (
     sd_CIE_illuminant_D_series,
     sd_blackbody,
 )
+from colour.characterisation import camera_RGB_to_ACES2065_1
 from colour.models import RGB_COLOURSPACE_ACES2065_1
 from colour.temperature import CCT_to_xy_CIE_D
 from colour.utilities import as_float, as_int_scalar
@@ -50,7 +51,6 @@ from dash_uploader import Upload, callback, configure_upload
 from datetime import datetime
 
 from aces.idt import (
-    apply_idt,
     archive_to_idt,
     error_delta_E,
     generate_reference_colour_checker,
@@ -849,11 +849,15 @@ def compute_idt_prosumer_camera(
         "colour_checker"
     ][0]["samples_median"]
 
-    samples_idt = apply_idt(
-        samples_median,
-        data_archive_to_idt.data_decode_samples.LUT_decoding,
+    samples_idt = camera_RGB_to_ACES2065_1(
+        data_archive_to_idt.data_decode_samples.LUT_decoding.apply(
+            samples_median
+        ),
         data_archive_to_idt.data_matrix_idt.M,
+        data_archive_to_idt.data_matrix_idt.RGB_w,
+        data_archive_to_idt.data_matrix_idt.k,
     )
+
     compare_colour_checkers_idt_correction = png_compare_colour_checkers(
         RGB_working_to_RGB_display(samples_idt),
         RGB_working_to_RGB_display(reference_colour_checker),

--- a/apps/idt_calculator_prosumer_camera.py
+++ b/apps/idt_calculator_prosumer_camera.py
@@ -276,22 +276,6 @@ _LAYOUT_COLUMN_OPTIONS_CHILDREN = [
                             ),
                             InputGroup(
                                 [
-                                    InputGroupText("Whitepoint Preservation"),
-                                    Select(
-                                        id=_uid(
-                                            "whitepoint-preservation-select"
-                                        ),
-                                        options=[
-                                            {"label": "1", "value": "1"},
-                                            {"label": "0", "value": "0"},
-                                        ],
-                                        value="0",
-                                    ),
-                                ],
-                                className="mb-1",
-                            ),
-                            InputGroup(
-                                [
                                     InputGroupText("Illuminant Interpolator"),
                                     Select(
                                         id=_uid(
@@ -729,7 +713,6 @@ def download_idt_zip(n_clicks):
         State(_uid("illuminant-datatable"), "data"),
         State(_uid("chromatic-adaptation-transform-select"), "value"),
         State(_uid("optimisation-space-select"), "value"),
-        State(_uid("whitepoint-preservation-select"), "value"),
         State(_uid("illuminant-interpolator-select"), "value"),
         State(_uid("decoding-method-select"), "value"),
         State(_uid("ev-range-input"), "value"),
@@ -747,7 +730,6 @@ def compute_idt_prosumer_camera(
     illuminant_data,
     chromatic_adaptation_transform,
     optimisation_space,
-    whitepoint_preservation,
     illuminant_interpolator,
     decoding_method,
     EV_range,
@@ -775,9 +757,6 @@ def compute_idt_prosumer_camera(
     optimisation_space : str
         Name of the optimisation space used to select the corresponding
         optimisation factory.
-    whitepoint_preservation : str
-        Whether to use whitepoint preservation, i.e. optimisation uses 6 terms
-        instead of 9 and rows summation is constrained to 1.
     illuminant_interpolator : str
         Name of the illuminant interpolator.
     decoding_method : str
@@ -843,7 +822,6 @@ def compute_idt_prosumer_camera(
             "EV_range": np.loadtxt([EV_range]),
             "training_data": reference_colour_checker,
             "optimisation_factory": OPTIMISATION_FACTORIES[optimisation_space],
-            "whitepoint_preservation": bool(int(whitepoint_preservation)),
         },
         additional_data=True,
     )
@@ -917,7 +895,6 @@ def compute_idt_prosumer_camera(
             "IlluminantData": parsed_illuminant_data,
             "ChromaticAdaptationTransform": chromatic_adaptation_transform,
             "OptimisationSpace": optimisation_space,
-            "WhitePreservation": whitepoint_preservation,
             "IlluminantInterpolator": illuminant_interpolator,
             "DecodingMethod": decoding_method,
             "EVRange": EV_range,


### PR DESCRIPTION
This PR implements support for "colour" latest update WRT whitepoint preservation. ~I think it is working now!~

There are still some problems left with the Prosumer Camera: Long story short, on that path, we never generate white balance multipliers so the matrix does both. The consequence is that if we do whitepoint preservation, then we are missing the neutralisation part.