### PR TITLE
PR: Fix issue introduced when adding `baseline_exposure` property.

### DIFF
--- a/apps/idt_calculator_prosumer_camera.py
+++ b/apps/idt_calculator_prosumer_camera.py
@@ -1204,11 +1204,13 @@ def compute_idt_prosumer_camera(
         _CACHE_DATA_ARCHIVE_TO_SAMPLES[_PATH_UPLOADED_IDT_ARCHIVE] = (
             _IDT_GENERATOR.specification,
             _IDT_GENERATOR.samples_analysis,
+            _IDT_GENERATOR.baseline_exposure,
         )
     else:
         (
             _IDT_GENERATOR._specification,
             _IDT_GENERATOR._samples_analysis,
+            _IDT_GENERATOR._baseline_exposure,
         ) = _CACHE_DATA_ARCHIVE_TO_SAMPLES[_PATH_UPLOADED_IDT_ARCHIVE]
 
     aces_transform_id = _IDT_GENERATOR.specification["header"][


### PR DESCRIPTION
The property value was not cached thus not existing when the cache was queried.