### PR TITLE
Publish Packages Preperation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ classifiers = [
     "Topic :: Software Development"
 ]
 
+packages = [
+    { include = "aces" },
+    { include = "apps" },
+    { include = "*.py" }
+]
+
 [tool.poetry.dependencies]
 python = ">= 3.9, < 3.13"
 colour-datasets = ">= 0.2.5"


### PR DESCRIPTION
We are now at a point where this is very close to doing everything that was intended and more, I want to start the discussion of how we can publish these to pypi so we can install with regular pip workflows etc.

I had to make a small change to the .toml file as we now have multiple packages within the repo so had to tell the poetry build command what to do.

This works and a whl is produce which can be installed and runs perfectly well.

However it brings us back to an older discussion

1) The aces.idt package seperate from the app package

Right now when we build the whl we get a single package which includes both the aces package and the apps package.
Including the apps package introduces a lot of web ui dependencies that we do not really want to include if you only want to use the core modules etc.

This would mean we need to do a minor cleanup moving the tests back under the relevent package (sorry thomas i know you had it that way to start), and adding a seperarte .toml file in each package so we can publish the aces package seperate from the apps package

Dragging in all the additional flask related stuff is going to cause conflicts and bloat

This feels like the best thing to do but want to have that conversation

2) Where are we publishing and what are we naming these packages

Obviously in that case we cant publish a package called "apps" so we will need to name that?
Then where and under what names do we want to publish these packages?

3) CI/CD
Ideally once this is working we then extend the CI/CD to get this runnig tests, building and publishing 


