### PR TITLE
Feature/python3 13 support

### DIFF
--- a/aces/idt/core/constants.py
+++ b/aces/idt/core/constants.py
@@ -104,14 +104,9 @@ class RGBDisplayColourspace:
     ALL: ClassVar[tuple[str, ...]] = (SRGB, DCI_P3)
 
 
-class CAT:
-    """Constants for the chromatic adaptation transforms."""
-
-    DEFAULT: ClassVar[str] = "CAT02"
-
-    @classmethod
+class CATMeta(type):
     @property
-    def ALL(cls) -> Tuple[str]:
+    def ALL(cls) -> Tuple[str, ...]:
         """
         Return all the available chromatic adaptation transforms.
 
@@ -120,8 +115,13 @@ class CAT:
         :class:`tuple`
             Available chromatic adaptation transforms.
         """
+        return (*sorted(colour.CHROMATIC_ADAPTATION_TRANSFORMS), "None")
 
-        return *sorted(colour.CHROMATIC_ADAPTATION_TRANSFORMS), "None"
+
+class CAT(metaclass=CATMeta):
+    """Constants for the chromatic adaptation transforms."""
+
+    DEFAULT: ClassVar[str] = "CAT02"
 
 
 class OptimizationSpace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.11, < 3.13"
+python = ">= 3.11, < 3.14"
 colour-datasets = ">= 0.2.5"
 colour-checker-detection = ">= 0.2.1"
 colour_science = ">= 0.4.5"
@@ -51,7 +51,7 @@ dash-renderer = "*"
 dash-uploader = "*"
 gunicorn = "*"
 imageio = ">= 2, < 3"
-pandas = ">= 1.4, < 2"
+pandas = ">= 1.4, < 2.3"
 jsonpickle = ">= 2, < 3"
 matplotlib = ">= 3.5, != 3.5.0, != 3.5.1"
 networkx = ">= 2.7, < 3"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,13 @@
+"""
+Unit tests for the constants module
+"""
+from aces.idt.core import constants
+from tests.test_utils import TestIDTBase
+
+
+class Test_IDTConstants(TestIDTBase):
+    """Class which holds the unit tests for the constants module"""
+
+    def test_class_property_deprecation(self):
+        """Test the deprecation of the classmethod and  property in python3.11"""
+        self.assertEqual(len(constants.CAT.ALL), 13)


### PR DESCRIPTION
Added small changes to ensure that the project is compatible all the way to python3.13

There was a deprecation in python3.11 where @classmethod and @propery decorators could no longer be used together.

Migrated To MetaClass vs multiple decorators
Added Unit Test
Updated pyproject.toml to update version boundaries for python3.13 support but also working with python3.11, 3.12 
