### PR TITLE
Looks like the illuminant_name from the UI was never passed through

### DIFF
--- a/apps/idt_calculator_prosumer_camera.py
+++ b/apps/idt_calculator_prosumer_camera.py
@@ -1349,6 +1349,7 @@ def compute_idt_prosumer_camera(
         debayering_settings=debayering_settings,
         encoding_colourspace=encoding_colourspace,
         encoding_transfer_function=encoding_transfer_function,
+        illuminant=illuminant_name,
     )
     _IDT_GENERATOR_APPLICATION = IDTGeneratorApplication(
         generator_name, project_settings


### PR DESCRIPTION
During testing found that whilst the core ui was working as expected the app never actually passed the illuminant name through to the backend