### PR TITLE
fix: Resolve custom illuminant crash and add advanced CLF controls

### DIFF
--- a/aces/idt/generators/log_camera.py
+++ b/aces/idt/generators/log_camera.py
@@ -510,6 +510,7 @@ class IDTGeneratorLogCamera(IDTBaseGenerator):
             self._M,
             target_white_point=self.project_settings.illuminant,
             chromatic_adaptation_transform=self.project_settings.cat,
+            **({"custom_illuminant_sd": self.project_settings.custom_illuminant} if self.project_settings.illuminant == "Custom" else {}),
         )
 
         return self._M, self._RGB_w, self._k

--- a/apps/idt_calculator_camera.py
+++ b/apps/idt_calculator_camera.py
@@ -418,6 +418,66 @@ _LAYOUT_COLUMN_SETTINGS_CHILDREN = [
                                 delay=DELAY_TOOLTIP_DEFAULT,
                                 target=_uid("ev-range-input"),
                             ),
+                            InputGroup(
+                                [
+                                    InputGroupText("Flatten CLF"),
+                                    Select(
+                                        id=_uid("flatten-clf-select"),
+                                        options=[
+                                            {"label": "Yes", "value": "True"},
+                                            {"label": "No", "value": "False"},
+                                        ],
+                                        value="False",
+                                    ),
+                                ],
+                                className="mb-1",
+                            ),
+                            Tooltip(
+                                "Whether to flatten the CLF into a single "
+                                "1D Lut & 1 3x3 Matrix.",
+                                delay=DELAY_TOOLTIP_DEFAULT,
+                                target=_uid("flatten-clf-select"),
+                            ),
+                            InputGroup(
+                                [
+                                    InputGroupText("Include White Balance in CLF"),
+                                    Select(
+                                        id=_uid("include-white-balance-in-clf-select"),
+                                        options=[
+                                            {"label": "Yes", "value": "True"},
+                                            {"label": "No", "value": "False"},
+                                        ],
+                                        value="True",
+                                    ),
+                                ],
+                                className="mb-1",
+                            ),
+                            Tooltip(
+                                "Whether to include the white balance "
+                                "multipliers in the CLF.",
+                                delay=DELAY_TOOLTIP_DEFAULT,
+                                target=_uid("include-white-balance-in-clf-select"),
+                            ),
+                            InputGroup(
+                                [
+                                    InputGroupText("Include Exposure Factor in CLF"),
+                                    Select(
+                                        id=_uid("include-exposure-factor-in-clf-select"),
+                                        options=[
+                                            {"label": "Yes", "value": "True"},
+                                            {"label": "No", "value": "False"},
+                                        ],
+                                        value="True",
+                                    ),
+                                ],
+                                className="mb-1",
+                            ),
+                            Tooltip(
+                                'Whether to include the exposure factor "k" '
+                                "in the CLF.",
+                                delay=DELAY_TOOLTIP_DEFAULT,
+                                target=_uid("include-exposure-factor-in-clf-select"),
+                            ),
                         ],
                         id=_uid("advanced-options-collapse"),
                         className="mb-1",
@@ -1150,6 +1210,9 @@ def toggle_modal(n_clicks, is_open):
         State(_uid("grey-card-reflectance"), "value"),
         State(_uid("lut-size-select"), "value"),
         State(_uid("lut-smoothing-input-number"), "value"),
+        State(_uid("flatten-clf-select"), "value"),
+        State(_uid("include-white-balance-in-clf-select"), "value"),
+        State(_uid("include-exposure-factor-in-clf-select"), "value"),
     ],
     prevent_initial_call=True,
 )
@@ -1179,6 +1242,9 @@ def compute_idt_camera(
     grey_card_reflectance,
     LUT_size,
     LUT_smoothing,
+    flatten_clf,
+    include_white_balance_in_clf,
+    include_exposure_factor_in_clf,
 ):
     """
     Compute the *Input Device Transform* (IDT) for a camera.
@@ -1238,6 +1304,12 @@ def compute_idt_camera(
     LUT_smoothing : integer
         Standard deviation of the gaussian convolution kernel used for
         smoothing.
+    flatten_clf : str
+        Whether to flatten the CLF into a single 1D Lut & 1 3x3 Matrix.
+    include_white_balance_in_clf : str
+        Whether to include the white balance multipliers in the CLF.
+    include_exposure_factor_in_clf : str
+        Whether to include the exposure factor "k" in the CLF.
 
     Returns
     -------
@@ -1257,7 +1329,10 @@ def compute_idt_camera(
         '\tEV Range : "%s"\n'
         '\tGrey Card Reflectance : "%s"\n'
         '\tLUT Size : "%s"\n'
-        '\tLUT Smoothing : "%s"\n',
+        '\tLUT Smoothing : "%s"\n'
+        '\tFlatten CLF : "%s"\n'
+        '\tInclude White Balance in CLF : "%s"\n'
+        '\tInclude Exposure Factor in CLF : "%s"\n',
         generator_name,
         RGB_display_colourspace,
         illuminant_name,
@@ -1270,6 +1345,9 @@ def compute_idt_camera(
         grey_card_reflectance,
         LUT_size,
         LUT_smoothing,
+        flatten_clf,
+        include_white_balance_in_clf,
+        include_exposure_factor_in_clf,
     )
 
     aces_transform_id = str(aces_transform_id)
@@ -1284,6 +1362,8 @@ def compute_idt_camera(
     debayering_settings = str(debayering_settings)
     encoding_colourspace = str(encoding_colourspace or "")
     encoding_transfer_function = str(encoding_transfer_function or "")
+    LUT_size = int(LUT_size)
+    LUT_smoothing = int(LUT_smoothing)
 
     # Validation: Check if the inputs are valid
     is_valid, errors = IDTProjectSettings.validate_core_requirements(
@@ -1359,7 +1439,27 @@ def compute_idt_camera(
         encoding_colourspace=encoding_colourspace,
         encoding_transfer_function=encoding_transfer_function,
         illuminant=illuminant_name,
+        rgb_display_colourspace=RGB_display_colourspace,
+        cat=chromatic_adaptation_transform,
+        optimisation_space=optimisation_space,
+        illuminant_interpolator=illuminant_interpolator,
+        decoding_method=decoding_method,
+        ev_range=[float(value) for value in EV_range.split(" ") if value],
+        grey_card_reference=[
+            float(value) for value in grey_card_reflectance.split(" ") if value
+        ],
+        lut_size=LUT_size,
+        lut_smoothing=LUT_smoothing,
+        flatten_clf=(lambda v: True if v == "True" else False)(flatten_clf),
+        include_white_balance_in_clf=(lambda v: True if v == "True" else False)(
+            include_white_balance_in_clf),
+        include_exposure_factor_in_clf=(lambda v: True if v == "True" else False)(
+            include_exposure_factor_in_clf),
     )
+
+    if illuminant_name == "Custom":
+        project_settings.custom_illuminant = illuminant
+
     _IDT_GENERATOR_APPLICATION = IDTGeneratorApplication(
         generator_name, project_settings
     )
@@ -1372,16 +1472,27 @@ def compute_idt_camera(
         _IDT_GENERATOR_APPLICATION.extract(_PATH_UPLOADED_IDT_ARCHIVE)
         os.remove(_PATH_UPLOADED_IDT_ARCHIVE)
         _IDT_GENERATOR_APPLICATION.generator.sample()
+        colour_checker_segmentation = (
+            _IDT_GENERATOR_APPLICATION.generator.png_colour_checker_segmentation()
+        )
+        grey_card_sampling = (
+            _IDT_GENERATOR_APPLICATION.generator.png_grey_card_sampling()
+        )
+
         _CACHE_DATA_ARCHIVE_TO_SAMPLES[_HASH_IDT_ARCHIVE] = (
             _IDT_GENERATOR_APPLICATION.project_settings.data,
             _IDT_GENERATOR_APPLICATION.generator.samples_analysis,
             _IDT_GENERATOR_APPLICATION.generator.baseline_exposure,
+            colour_checker_segmentation,
+            grey_card_sampling,
         )
     else:
         (
             _IDT_GENERATOR_APPLICATION.project_settings.data,
             _IDT_GENERATOR_APPLICATION.generator._samples_analysis,  # noqa: SLF001
             _IDT_GENERATOR_APPLICATION.generator._baseline_exposure,  # noqa: SLF001
+            colour_checker_segmentation,
+            grey_card_sampling,
         ) = _CACHE_DATA_ARCHIVE_TO_SAMPLES[_HASH_IDT_ARCHIVE]
 
     generator = _IDT_GENERATOR_APPLICATION.generator
@@ -1481,7 +1592,6 @@ def compute_idt_camera(
     ]
 
     # Segmentation
-    colour_checker_segmentation = generator.png_colour_checker_segmentation()
     if colour_checker_segmentation is not None:
         components += [
             H3("Segmentation", style={"textAlign": "center"}),
@@ -1490,7 +1600,6 @@ def compute_idt_camera(
                 style={"width": "100%"},
             ),
         ]
-    grey_card_sampling = generator.png_grey_card_sampling()
     if grey_card_sampling is not None:
         components += [
             Img(


### PR DESCRIPTION
This PR addresses a critical crash related to custom illuminant handling and resolves several bugs within the camera calculator. It also introduces new, advanced controls for CLF generation to provide users with more flexibility.

### **Summary of Changes**

This pull request contains two main categories of changes: bug fixes and new features.

#### Bug Fixes

* **Custom Illuminant Crash:** Resolves a critical stability issue where the application would crash upon selecting the "Custom" illuminant. The system now correctly handles and processes user-provided spectral power distribution (SPD) data throughout the pipeline.
* **White Point Calculation:** Corrects the white point calculation method used for custom illuminant SPDs in `aces/idt/core/common.py`.
* **UI Parameter Handling:** Fixes a bug in the `idt_calculator_camera` where parameters set in the UI (such as `RGB_display_colourspace`, `optimisation_space`, and `LUT Size`) were not being correctly transmitted to or processed by the backend.
* **Image Caching:** Resolves a caching issue that prevented analysis images (e.g., `colour_checker_segmentation`) from being displayed correctly on subsequent calculations.
* **Debugging:** Adds enhanced debugging logs for CLF generation options and the final transformation matrix to assist with future troubleshooting.

#### New Features

* **Advanced CLF Generation Controls:** To provide more granular control over the output, three new boolean toggles have been added to the camera calculator UI:
    * `Flatten CLF`
    * `Include White Balance in CLF`
    * `Include Exposure Factor in CLF`