### PR TITLE
FIx a bug to add missing BlackBody & Daylight Options

### DIFF
--- a/aces/idt/core/constants.py
+++ b/aces/idt/core/constants.py
@@ -312,6 +312,15 @@ class ProjectSettingsMetadataConstants:
         ui_category=UICategories.STANDARD,
     )
 
+    ILLUMINANT_CUSTOM_TEMPERATURE = Metadata(
+        name="illuminant_custom_temperature",
+        default_value=6500,
+        description="The temperature in Kelvin for Blackbody or Daylight illuminants",
+        display_name="Illuminant Temperature (K)",
+        ui_type=UITypes.INT_FIELD,
+        ui_category=UICategories.ADVANCED,
+    )
+
     ADDITIONAL_CAMERA_SETTINGS = Metadata(
         name="additional_camera_settings",
         default_value="",
@@ -488,6 +497,7 @@ class ProjectSettingsMetadataConstants:
         ACES_USER_NAME,
         ISO,
         TEMPERATURE,
+        ILLUMINANT_CUSTOM_TEMPERATURE,
         ADDITIONAL_CAMERA_SETTINGS,
         LIGHTING_SETUP_DESCRIPTION,
         DEBAYERING_PLATFORM,

--- a/aces/idt/framework/project_settings.py
+++ b/aces/idt/framework/project_settings.py
@@ -85,6 +85,10 @@ class IDTProjectSettings(MixinSerializableProperties):
             IDTProjectSettings.temperature.metadata.name,
             IDTProjectSettings.temperature.metadata.default_value,
         )
+        self._illuminant_custom_temperature = kwargs.get(
+            IDTProjectSettings.illuminant_custom_temperature.metadata.name,
+            IDTProjectSettings.illuminant_custom_temperature.metadata.default_value,
+        )
         self._additional_camera_settings = kwargs.get(
             IDTProjectSettings.additional_camera_settings.metadata.name,
             IDTProjectSettings.additional_camera_settings.metadata.default_value,
@@ -290,6 +294,30 @@ class IDTProjectSettings(MixinSerializableProperties):
         """
 
         return self._temperature
+
+    @metadata_property(metadata=MetadataConstants.ILLUMINANT_CUSTOM_TEMPERATURE)
+    def illuminant_custom_temperature(self) -> int:
+        """
+        Getter property for the illuminant custom temperature in Kelvin degrees.
+
+        This property is used when the illuminant is set to "Blackbody" or
+        "Daylight". It specifies the correlated colour temperature (CCT) in
+        Kelvin for generating the spectral distribution.
+
+        Returns
+        -------
+        :class:`int`
+            Illuminant custom temperature in Kelvin degrees.
+
+        Notes
+        -----
+        -   For Blackbody illuminants, this temperature is used directly with
+            Planck's law to generate the spectral power distribution.
+        -   For Daylight illuminants, this temperature is used to generate a
+            CIE D Series illuminant at the specified CCT.
+        """
+
+        return self._illuminant_custom_temperature
 
     @metadata_property(metadata=MetadataConstants.ADDITIONAL_CAMERA_SETTINGS)
     def additional_camera_settings(self) -> str:
@@ -638,9 +666,16 @@ class IDTProjectSettings(MixinSerializableProperties):
             Reference colour checker samples.
         """
 
+        # Pass illuminant_custom_temperature if illuminant is "Blackbody" or "Daylight"
+        temperature = (
+            self.illuminant_custom_temperature
+            if self.illuminant in ("Blackbody", "Daylight")
+            else None
+        )
+
         return generate_reference_colour_checker(
             get_sds_colour_checker(self.reference_colour_checker),
-            get_sds_illuminant(self.illuminant),
+            get_sds_illuminant(self.illuminant, temperature=temperature),
         )
 
     def get_optimization_factory(self) -> callable:

--- a/tests/resources/example_from_folder.json
+++ b/tests/resources/example_from_folder.json
@@ -29,6 +29,7 @@
     "cleanup": true,
     "reference_colour_checker": "ISO 17321-1",
     "illuminant": "D60",
+    "illuminant_custom_temperature": 6500,
     "file_type": "",
     "ev_weights": [],
     "optimization_kwargs": {}

--- a/tests/resources/synthetic_001/test_project.json
+++ b/tests/resources/synthetic_001/test_project.json
@@ -7,6 +7,7 @@
     "camera_model": "",
     "iso": 800,
     "temperature": 6000,
+    "illuminant_custom_temperature": 6500,
     "additional_camera_settings": "",
     "lighting_setup_description": "",
     "debayering_platform": "",

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -102,6 +102,7 @@ File_Type                      :
 Flatten_Clf                    : False
 Grey_Card_Reference            : [ 0.18  0.18  0.18]
 Illuminant                     : D60
+Illuminant_Custom_Temperature  : 6500
 Illuminant_Interpolator        : Linear
 Include_Exposure_Factor_In_Clf : False
 Include_White_Balance_In_Clf   : False


### PR DESCRIPTION
The Daylight and Blackbody options have been used by folks in production who reported it not working.
Needed to add handling to pass the custom temperature through to the backend
Needed to add in the code to calculate and get the illuminent for those two options